### PR TITLE
Add Context7 indexing config

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "https://context7.com/schema/context7.json",
+    "projectTitle": "react-mnemonic",
+    "description": "AI-friendly, persistent, type-safe state management for React.",
+    "folders": ["website/docs/ai", "website/docs/getting-started", "website/docs/guides", "website/static", "src"],
+    "excludeFolders": [
+        "node_modules",
+        "website/node_modules",
+        "website/.docusaurus",
+        "website/build",
+        "website/docs/api",
+        "dist",
+        "docs",
+        "coverage",
+        "fixtures",
+        "devtools-extension/dist"
+    ],
+    "excludeFiles": [],
+    "rules": [
+        "Prefer website/docs/ai as the canonical source for persistence semantics, invariants, and decision rules.",
+        "Treat README.md and src/index.ts as the public package surface and prefer published entrypoints over internal paths.",
+        "Use react-mnemonic/core for the lean persisted-state path and react-mnemonic/schema when validation, versioning, or migrations are required.",
+        "Durable app state should use MnemonicProvider and useMnemonicKey rather than raw localStorage in consumer-facing code.",
+        "Treat excluded build outputs as derived artifacts rather than source-of-truth documentation."
+    ],
+    "url": "https://context7.com/thirtytwobits/react-mnemonic",
+    "public_key": "pk_LoqAGzuI6DGtcnxmLnh2v"
+}

--- a/website/docs/ai/assistant-setup.md
+++ b/website/docs/ai/assistant-setup.md
@@ -24,6 +24,7 @@ Everything else is a companion surface:
 - [`/llms.txt`](/llms.txt) for compact retrieval
 - [`/llms-full.txt`](/llms-full.txt) for long-form export
 - [`/ai-contract.json`](/ai-contract.json) for machine-readable summaries
+- [`context7.json`](https://github.com/thirtytwobits/react-mnemonic/blob/main/context7.json) for Context7 library-owner indexing
 - repository instruction packs for Codex, Claude Code, Cursor, and Copilot
 - [`.devin/wiki.json`](https://github.com/thirtytwobits/react-mnemonic/blob/main/.devin/wiki.json) for DeepWiki prioritization
 
@@ -119,6 +120,7 @@ Keep the surfaces aligned this way:
 - edit the canonical prose in `website/docs/ai/*`
 - regenerate companion assets and instruction packs via `npm run docs:ai`
 - use `npm run ai:check` in CI or before commits to catch drift in generated AI artifacts and instruction packs
+- keep `context7.json` aligned with the same high-signal docs and public API entry points
 - keep the DeepWiki priorities in `.devin/wiki.json` aligned with the same sources
 
 The goal is simple: agents should load one canonical contract and then choose

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -614,6 +614,7 @@ Everything else is a companion surface:
 - [`/llms.txt`](https://thirtytwobits.github.io/react-mnemonic/llms.txt) for compact retrieval
 - [`/llms-full.txt`](https://thirtytwobits.github.io/react-mnemonic/llms-full.txt) for long-form export
 - [`/ai-contract.json`](https://thirtytwobits.github.io/react-mnemonic/ai-contract.json) for machine-readable summaries
+- [`context7.json`](https://github.com/thirtytwobits/react-mnemonic/blob/main/context7.json) for Context7 library-owner indexing
 - repository instruction packs for Codex, Claude Code, Cursor, and Copilot
 - [`.devin/wiki.json`](https://github.com/thirtytwobits/react-mnemonic/blob/main/.devin/wiki.json) for DeepWiki prioritization
 
@@ -709,6 +710,7 @@ Keep the surfaces aligned this way:
 - edit the canonical prose in `website/docs/ai/*`
 - regenerate companion assets and instruction packs via `npm run docs:ai`
 - use `npm run ai:check` in CI or before commits to catch drift in generated AI artifacts and instruction packs
+- keep `context7.json` aligned with the same high-signal docs and public API entry points
 - keep the DeepWiki priorities in `.devin/wiki.json` aligned with the same sources
 
 The goal is simple: agents should load one canonical contract and then choose


### PR DESCRIPTION
## Summary
- add a root `context7.json` so Context7 can prioritize canonical docs and public API entry points
- document the file in the AI assistant setup guide
- regenerate the derived AI retrieval artifact that reflects the assistant setup docs

## Testing
- npm run docs:ai
- npm run ai:check
- npm run format:check

Closes #49