### PR TITLE
Deploy docs only on release tags

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,9 +2,8 @@ name: Deploy Docs
 
 on:
     push:
-        branches:
-            - main
-    workflow_dispatch:
+        tags:
+            - "v*"
 
 concurrency:
     group: pages


### PR DESCRIPTION
## Summary
- restrict the Pages deploy workflow to `v*` tag pushes
- remove manual dispatch so non-release docs cannot be published

## Validation
- npx prettier --check .github/workflows/deploy-docs.yml

This keeps GitHub Pages deployments aligned with tagged releases only.