### PR TITLE
Fix GitHub Pages artifact deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -4,6 +4,7 @@ on:
     push:
         tags:
             - "v*"
+    workflow_dispatch:
 
 concurrency:
     group: pages
@@ -14,6 +15,8 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: read
+            pages: write
+            id-token: write
         defaults:
             run:
                 working-directory: website
@@ -45,9 +48,13 @@ jobs:
               env:
                   NODE_OPTIONS: "--max-old-space-size=4096"
 
+            - name: Configure GitHub Pages
+              uses: actions/configure-pages@v5
+
             - name: Upload Pages artifact
-              uses: actions/upload-pages-artifact@v3
+              uses: actions/upload-pages-artifact@v4
               with:
+                  name: github-pages
                   path: website/build
 
     deploy:
@@ -63,3 +70,5 @@ jobs:
             - name: Deploy to GitHub Pages
               id: deployment
               uses: actions/deploy-pages@v4
+              with:
+                  artifact_name: github-pages


### PR DESCRIPTION
## Summary
Fix the GitHub Pages workflow so the deploy job can find and publish the built docs artifact.

## What changed
- add `workflow_dispatch` so docs deploys can be retried manually
- add `actions/configure-pages@v5` to the build job
- upgrade `actions/upload-pages-artifact` from `v3` to `v4`
- make the Pages artifact name explicit on upload and deploy
- add the required Pages permissions to the build job

## Why
The latest docs deploy was failing with `No artifacts named "github-pages" were found for this workflow run`, even though the Docusaurus site itself built successfully.

## Testing
- `npm run build`
- `npm run typedoc` in `website/`
- `npm run build` in `website/`
- YAML parse check for `.github/workflows/deploy-docs.yml`