### PR TITLE
Add undo-focused cross-links to react-amnesia

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ AI-friendly, persistent, type-safe state for React.
 
 `react-mnemonic` gives your components persistent memory through a hook that feels like `useState`. Values survive reloads, can stay in sync across tabs, and remain SSR-safe by default. It is designed to be AI-friendly, prioritizing visible structure and unambiguous specifications. When you need more than raw storage, the package can validate, version, and migrate persisted data.
 
+## Need an "undo" stack?
+
+See our sister project, `react-amnesia`, an undo/redo framework for React:
+
+- [react-amnesia on GitHub](https://github.com/thirtytwobits/react-amnesia)
+- [react-amnesia documentation](https://thirtytwobits.github.io/react-amnesia/docs/getting-started/installation)
+
 ## Installation
 
 ```bash

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -9,6 +9,10 @@ description: Get running with react-mnemonic in under a minute.
 Wrap your app in a `MnemonicProvider`, then call `useMnemonicKey` anywhere
 inside it.
 
+Need an "undo" stack? See our sister project, [react-amnesia](https://github.com/thirtytwobits/react-amnesia),
+an undo/redo framework for React, and its
+[documentation](https://thirtytwobits.github.io/react-amnesia/docs/getting-started/installation).
+
 ```tsx title="App.tsx"
 import { MnemonicProvider, useMnemonicKey } from "react-mnemonic/core";
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -136,6 +136,11 @@ const config: Config = {
                     position: "right",
                 },
                 {
+                    href: "https://thirtytwobits.github.io/react-amnesia/docs/getting-started/installation",
+                    label: "Undo Stack Docs",
+                    position: "right",
+                },
+                {
                     href: "https://www.npmjs.com/package/react-mnemonic",
                     label: "npm",
                     position: "right",
@@ -171,6 +176,10 @@ const config: Config = {
                     title: "More",
                     items: [
                         { label: "GitHub", href: "https://github.com/thirtytwobits/react-mnemonic" },
+                        {
+                            label: "Undo Stack (react-amnesia)",
+                            href: "https://thirtytwobits.github.io/react-amnesia/docs/getting-started/installation",
+                        },
                         { label: "npm", href: "https://www.npmjs.com/package/react-mnemonic" },
                     ],
                 },


### PR DESCRIPTION
## Summary

- add README cross-links to react-amnesia framed as undo/redo usage
- add Quick Start docs cross-link with undo-stack wording
- add docs navbar/footer link labels that indicate undo-stack docs
 
## Testing

- npx prettier --check README.md website/docs/getting-started/quick-start.md website/docusaurus.config.ts